### PR TITLE
run npm install for lazysizes node_module from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,5 +46,13 @@
         "psr-4": {
             "Frosh\\ThumbnailProcessor\\": "src/"
         }
+    },
+    "scripts": {
+        "post-install-cmd": [
+            "[ $COMPOSER_DEV_MODE -eq 0 ] || (cd src/Resources/app/storefront && npm install);"
+        ],
+        "post-update-cmd": [
+            "[ $COMPOSER_DEV_MODE -eq 0 ] || (cd src/Resources/app/storefront && npm install);"
+        ]
     }
 }


### PR DESCRIPTION
When lazysizes node_module is not included in the git repo it won't be installed on requiring the plugin and you need to manually install it. This will work until vendor is not being removed or updated, which often happens when running project with CI/CD approach.

The commands in the composer scripts should automize the manual ran of npm install and the node_module will be required every time the composer package is required.