### PR TITLE
avoid metaProportion calculation if image is not loaded or broken

### DIFF
--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -19,7 +19,9 @@
     {% endif %}
 
     {% set metaProportion = media.metaData %}
-    {% set ratio = (metaProportion.width / metaProportion.height)|round(2, 'floor') %}
+    {% if metaProportion > 0 %}
+        {% set ratio = (metaProportion.width / metaProportion.height)|round(2, 'floor') %}
+    {% endif %}
 
     {% if layout == 'full-width' %}
         {% if ratio >= 1  %}


### PR DESCRIPTION
If it happens that an image is not loaded for some reason or broken you will get the following error:

Warning: Division by zero, pointing to -> src/Resources/views/storefront/utilities/thumbnail.html.twig line 22.

You can avoid that by checking if metaProportion is higher than 0