### PR TITLE
Added if statement to check if thumbnails are set

### DIFF
--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -21,7 +21,7 @@
     {% if media.thumbnails|length > 0 %}
         {% set thumbnails = media.thumbnails|filter((v) => v.width <= metaProportion.width)|sort|reverse %}
         
-        {% if thumbnails|first.width %}
+         {% if thumbnails %}
             {# generate srcset with all available thumbnails #}
             {% set srcsetValue %}{% apply spaceless %}
                 {{ media|sw_encode_media_url }} {{ thumbnails|first.width + 1 }}w, {% for thumbnail in thumbnails %}{{ thumbnail.url | sw_encode_url }} {{ thumbnail.width }}w{% if not loop.last %}, {% endif %}{% endfor %}

--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -20,11 +20,14 @@
     {% set metaProportion = media.metaData %}
     {% if media.thumbnails|length > 0 %}
         {% set thumbnails = media.thumbnails|filter((v) => v.width <= metaProportion.width)|sort|reverse %}
-
-        {# generate srcset with all available thumbnails #}
-        {% set srcsetValue %}{% apply spaceless %}
-            {{ media|sw_encode_media_url }} {{ thumbnails|first.width + 1 }}w, {% for thumbnail in thumbnails %}{{ thumbnail.url | sw_encode_url }} {{ thumbnail.width }}w{% if not loop.last %}, {% endif %}{% endfor %}
-        {% endapply %}{% endset %}
+        
+        {% if thumbnails|first.width %}
+            {# generate srcset with all available thumbnails #}
+            {% set srcsetValue %}{% apply spaceless %}
+                {{ media|sw_encode_media_url }} {{ thumbnails|first.width + 1 }}w, {% for thumbnail in thumbnails %}{{ thumbnail.url | sw_encode_url }} {{ thumbnail.width }}w{% if not loop.last %}, {% endif %}{% endfor %}
+            {% endapply %}{% endset %}
+        {% endif %}
+        
     {% endif %}
     {% set ratio = (metaProportion.width / max(metaProportion.height, 1))|round(3, 'floor') %}
 

--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -43,7 +43,9 @@
         <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
             data-src="{{ media|sw_encode_media_url }}"
             {% if media.thumbnails|length > 1 %}
-                data-srcset="{{ srcsetValue }}"
+                {% if srcsetValue %}
+                    data-srcset="{{ srcsetValue }}"
+                {% endif %}
                 data-sizes="auto"
                 data-aspectratio="{{ ratio }}"
                 data-parent-fit="contain"


### PR DESCRIPTION
This change will solve a bug that will happen when there is no `first.width` available. 

The code will now add one image in the `src-set` with `1w,` which does not work in Safari on the iPad and with this change it will not add any `src-set` if there are no images available to put in there.