### PR TITLE
feat: encode shopware media path without prefixes

### DIFF
--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -24,7 +24,7 @@
         {% if thumbnails %}
             {# generate srcset with all available thumbnails #}
             {% set srcsetValue %}{% apply spaceless %}
-                {{ media|sw_encode_media_url }} {{ thumbnails|first.width + 1 }}w, {% for thumbnail in thumbnails %}{{ thumbnail.url | sw_encode_url }} {{ thumbnail.width }}w{% if not loop.last %}, {% endif %}{% endfor %}
+                {{ media.url }} {{ thumbnails|first.width + 1 }}w, {% for thumbnail in thumbnails %}{{ thumbnail.url }} {{ thumbnail.width }}w{% if not loop.last %}, {% endif %}{% endfor %}
             {% endapply %}{% endset %}
         {% endif %}
     {% endif %}
@@ -41,7 +41,7 @@
 
     {% block thumbnail_utility_img %}
         <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
-            data-src="{{ media|sw_encode_media_url }}"
+            data-src="{{ media.url }}"
             {% if srcsetValue %}
                 data-srcset="{{ srcsetValue }}"
                 data-sizes="auto"

--- a/src/Service/ThumbnailUrlTemplate.php
+++ b/src/Service/ThumbnailUrlTemplate.php
@@ -21,6 +21,14 @@ class ThumbnailUrlTemplate implements ThumbnailUrlTemplateInterface
 
     public function getUrl(string $mediaUrl, string $mediaPath, string $width, string $height = ''): string
     {
+        $segments = \explode('/', $mediaPath);
+
+        foreach ($segments as $index => $segment) {
+            $segments[$index] = \rawurlencode($segment);
+        }
+
+        $mediaPath = implode('/', $segments);
+
         return str_replace(
             ['{mediaUrl}', '{mediaPath}', '{width}', '{height}'],
             [$mediaUrl, $mediaPath, $width, ''],


### PR DESCRIPTION
would fix new imgproxy urls