### PR TITLE
Removed last instance of sw_encode_media

### DIFF
--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -51,7 +51,7 @@
             {% for key, value in attributes %}
                 {{ key }}="{{ value }}"
                 {% if key == 'itemprop' %}
-                    content="{{ media|sw_encode_media_url }}"
+                    content="{{ media.url }}"
                 {% endif %}
             {% endfor %}
             {% if inlineStyle is defined %}


### PR DESCRIPTION
This is an addition to #34 

Removed one last call to sw_encode_media, which led to multiple images not loading (i.e. the logo in the header)