### PR TITLE
Add reset

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -8,6 +8,7 @@
 
         <service id="Frosh\ThumbnailProcessor\Service\UrlGeneratorDecorator"
                  decorates="Shopware\Core\Content\Media\Pathname\UrlGeneratorInterface">
+            <argument type="service" id="Shopware\Core\Content\Media\Pathname\PathnameStrategy\PathnameStrategyInterface"/>
             <argument type="service" id="Frosh\ThumbnailProcessor\Service\UrlGeneratorDecorator.inner"/>
             <argument type="service" id="Frosh\ThumbnailProcessor\Service\ThumbnailUrlTemplateInterface"/>
             <argument type="service" id="request_stack"/>

--- a/src/Service/UrlGeneratorDecorator.php
+++ b/src/Service/UrlGeneratorDecorator.php
@@ -8,8 +8,9 @@ use Shopware\Core\Content\Media\MediaType\ImageType;
 use Shopware\Core\Content\Media\Pathname\UrlGeneratorInterface;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Service\ResetInterface;
 
-class UrlGeneratorDecorator implements UrlGeneratorInterface
+class UrlGeneratorDecorator implements UrlGeneratorInterface, ResetInterface
 {
     /**
      * @var RequestStack
@@ -106,6 +107,11 @@ class UrlGeneratorDecorator implements UrlGeneratorInterface
     public function getRelativeThumbnailUrl(MediaEntity $media, MediaThumbnailEntity $thumbnail): string
     {
         return $this->getAbsoluteThumbnailUrl($media, $thumbnail);
+    }
+
+    public function reset(): void
+    {
+        $this->fallbackBaseUrl = null;
     }
 
     private function normalizeBaseUrl(?string $baseUrl): ?string

--- a/src/Service/UrlGeneratorDecorator.php
+++ b/src/Service/UrlGeneratorDecorator.php
@@ -5,6 +5,7 @@ namespace Frosh\ThumbnailProcessor\Service;
 use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Media\MediaType\ImageType;
+use Shopware\Core\Content\Media\Pathname\PathnameStrategy\PathnameStrategyInterface;
 use Shopware\Core\Content\Media\Pathname\UrlGeneratorInterface;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -21,6 +22,16 @@ class UrlGeneratorDecorator implements UrlGeneratorInterface, ResetInterface
      * @var string|null
      */
     private $baseUrl;
+
+    /**
+     * @var PathnameStrategyInterface
+     */
+    private $pathnameStrategy;
+
+    /**
+     * @var string|null
+     */
+    private $fallbackBaseUrl;
 
     /**
      * @var UrlGeneratorInterface
@@ -48,6 +59,7 @@ class UrlGeneratorDecorator implements UrlGeneratorInterface, ResetInterface
     private $systemConfigService;
 
     public function __construct(
+        PathnameStrategyInterface $pathnameStrategy,
         UrlGeneratorInterface $decoratedService,
         ThumbnailUrlTemplateInterface $thumbnailUrlTemplate,
         RequestStack $requestStack,
@@ -55,6 +67,7 @@ class UrlGeneratorDecorator implements UrlGeneratorInterface, ResetInterface
         ?string $baseUrl = null
     )
     {
+        $this->pathnameStrategy = $pathnameStrategy;
         $this->decoratedService = $decoratedService;
         $this->requestStack = $requestStack;
 
@@ -62,6 +75,11 @@ class UrlGeneratorDecorator implements UrlGeneratorInterface, ResetInterface
 
         $this->thumbnailUrlTemplate = $thumbnailUrlTemplate;
         $this->systemConfigService = $systemConfigService;
+    }
+
+    public function reset(): void
+    {
+        $this->fallbackBaseUrl = null;
     }
 
     public function getAbsoluteMediaUrl(MediaEntity $media): string
@@ -107,11 +125,6 @@ class UrlGeneratorDecorator implements UrlGeneratorInterface, ResetInterface
     public function getRelativeThumbnailUrl(MediaEntity $media, MediaThumbnailEntity $thumbnail): string
     {
         return $this->getAbsoluteThumbnailUrl($media, $thumbnail);
-    }
-
-    public function reset(): void
-    {
-        $this->fallbackBaseUrl = null;
     }
 
     private function normalizeBaseUrl(?string $baseUrl): ?string


### PR DESCRIPTION
Fix breaking change on interface

```
  "command" => "messenger:consume --time-limit=600 --memory-limit=1024M -vvv",
  "message" => "Call to undefined method Frosh\ThumbnailProcessor\Service\UrlGeneratorDecorator::reset()"
]
08:23:23 DEBUG     [console] Command "messenger:consume --time-limit=600 --memory-limit=1024M -vvv" exited with code "1"
[
  "command" => "messenger:consume --time-limit=600 --memory-limit=1024M -vvv",
  "code" => 1
]

In ServicesResetter.php line 47:
                                                                                                                          
  [Symfony\Component\ErrorHandler\Error\UndefinedMethodError]                                                             
  Attempted to call an undefined method named "reset" of class "Frosh\ThumbnailProcessor\Service\UrlGeneratorDecorator".

```