### PR TITLE
feat: set aspect-ratio within css to reduce CLS

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,9 @@
+# 1.1.0
+
+* Set aspect-ratio with inline-css to reserve space of images which reduces Cumulative Layout Shift (CLS)
+* Set class `frosh-proc` onto images managed by this plugin, use selector `img.frosh-proc` to set specific css style
+* Add usage of variable `src`. Use this to determine an own placeholder image or preload image.
+
 # 1.0.28
 
 * Beschränke Konfiguration auf "Alle Saleschannel"

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -1,3 +1,9 @@
+# 1.1.0
+
+* Set aspect-ratio with inline-css to reserve space of images which reduces Cumulative Layout Shift (CLS)
+* Set class `frosh-proc` onto images managed by this plugin, use selector `img.frosh-proc` to set specific css style
+* Add usage of variable `src`. Use this to determine an own placeholder image or preload image.
+
 # 1.0.28
 
 * Restrict configuration to "All Saleschannels"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "thumbnail"
     ],
     "description": "This plugins allows you to use variable thumbnails, without having them on storage.",
-    "version": "1.0.28",
+    "version": "1.1.0",
     "type": "shopware-platform-plugin",
     "license": "mit",
     "authors": [

--- a/src/Resources/app/storefront/src/scss/base.scss
+++ b/src/Resources/app/storefront/src/scss/base.scss
@@ -1,6 +1,2 @@
 // COMPONENTS
 @import 'component/cms-element';
-
-img.frosh-proc {
-    width: 100%;
-}

--- a/src/Resources/app/storefront/src/scss/base.scss
+++ b/src/Resources/app/storefront/src/scss/base.scss
@@ -1,2 +1,6 @@
 // COMPONENTS
 @import 'component/cms-element';
+
+img.frosh-proc {
+    width: 100%;
+}

--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -44,6 +44,7 @@
     {% endif %}
 
     {% block thumbnail_utility_img %}
+        <!--suppress HtmlRequiredAltAttribute -->
         <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
             data-src="{{ media.url|frosh_encode_url }}"
             {% if srcsetValue %}

--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -39,7 +39,11 @@
     {% endif %}
 
     {% block thumbnail_utility_img %}
-        <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+        {% if src is not defined %}
+            {% set src = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==' %}
+        {% endif %}
+
+        <img src="{{ src }}"
             data-src="{{ media.url|frosh_encode_url }}"
             {% if srcsetValue %}
                 data-srcset="{{ srcsetValue }}"

--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -39,7 +39,6 @@
     {% endif %}
 
     {% block thumbnail_utility_img %}
-        <!--suppress HtmlRequiredAltAttribute -->
         <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
             data-src="{{ media.url|frosh_encode_url }}"
             {% if srcsetValue %}

--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -4,9 +4,9 @@
     {% endif %}
 
     {% if attributes.class %}
-        {% set attributes = attributes|merge({'class': 'lazyload ' ~ attributes.class}) %}
+        {% set attributes = attributes|merge({'class': 'frosh-proc lazyload ' ~ attributes.class}) %}
     {% else %}
-        {% set attributes = attributes|merge({'class': 'lazyload'}) %}
+        {% set attributes = attributes|merge({'class': 'frosh-proc lazyload'}) %}
     {% endif %}
 
     {% if attributes.alt is not defined and media.translated.alt is defined %}
@@ -31,16 +31,11 @@
 
     {% set ratio = (metaProportion.width / max(metaProportion.height, 1))|round(3, 'floor') %}
 
-
-    {% set inlineStyle = "" %}
-    {% if fullWidth %}
-        {% if ratio >= 1  %}
-            {% set inlineStyle = inlineStyle ~ "width: 100vw; height: " ~ (100 / ratio)|round(3) ~ "vw;" %}
-        {% else %}
-            {% set inlineStyle = inlineStyle ~ "width: " ~ (100 * ratio)|round(3)~ "vw; height: 100vw;" %}
-        {% endif %}
+    {% set inlineStyle = "aspect-ratio:" ~ ratio ~ ";" %}
+    {% if attributes.style %}
+        {% set attributes = attributes|merge({'style': inlineStyle ~ attributes.style}) %}
     {% else %}
-        {% set inlineStyle = inlineStyle ~ "width: 100%; aspect-ratio: " ~ ratio|round(3) ~ ";" %}
+        {% set attributes = attributes|merge({'style': inlineStyle}) %}
     {% endif %}
 
     {% block thumbnail_utility_img %}
@@ -59,9 +54,6 @@
                     content="{{ media.url|frosh_encode_url }}"
                 {% endif %}
             {% endfor %}
-            {% if inlineStyle != "" %}
-                style="{{ inlineStyle }}"
-            {% endif %}
         />
 
     {% endblock %}

--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -31,12 +31,16 @@
 
     {% set ratio = (metaProportion.width / max(metaProportion.height, 1))|round(3, 'floor') %}
 
+
+    {% set inlineStyle = "" %}
     {% if fullWidth %}
         {% if ratio >= 1  %}
-            {% set inlineStyle = "width: 100vw; height: " ~ (100 / ratio)|round(3) ~ "vw" %}
+            {% set inlineStyle = inlineStyle ~ "width: 100vw; height: " ~ (100 / ratio)|round(3) ~ "vw;" %}
         {% else %}
-            {% set inlineStyle = "width: " ~ (100 * ratio)|round(3)~ "vw; height: 100vw" %}
+            {% set inlineStyle = inlineStyle ~ "width: " ~ (100 * ratio)|round(3)~ "vw; height: 100vw;" %}
         {% endif %}
+    {% else %}
+        {% set inlineStyle = inlineStyle ~ "width: 100%; aspect-ratio: " ~ ratio|round(3) ~ ";" %}
     {% endif %}
 
     {% block thumbnail_utility_img %}
@@ -54,7 +58,7 @@
                     content="{{ media.url|frosh_encode_url }}"
                 {% endif %}
             {% endfor %}
-            {% if inlineStyle is defined %}
+            {% if inlineStyle != "" %}
                 style="{{ inlineStyle }}"
             {% endif %}
         />


### PR DESCRIPTION
Looking for testers!

Real world example.

Before, see it jumping *jump, jump, jump* 🎵 :

https://user-images.githubusercontent.com/135993/178429306-e9bdf5f3-5968-41a1-b883-e038d3414e08.mp4

After, elements are on its place when loading:

https://user-images.githubusercontent.com/135993/178429395-c0665fda-345f-4e51-b0be-375f6517c937.mp4


