### PR TITLE
feature: allow passing media timestamp to image service

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,6 @@ jobs:
           shopware-version: ${{ matrix.version }}
           php-version: ${{ matrix.php-version }}
           php-extensions: pcov
-          install: true
 
       - name: Info
         run: |
@@ -74,7 +73,6 @@ jobs:
           shopware-version: ${{ matrix.version }}
           php-version: ${{ matrix.php-version }}
           php-extensions: pcov
-          install: true
 
       - name: Info
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
           shopware-version: ${{ matrix.version }}
           php-version: ${{ matrix.php-version }}
           php-extensions: pcov
+          install: true
 
       - name: Info
         run: |
@@ -32,7 +33,6 @@ jobs:
           mysql -V
           php -v
           composer -V
-          echo ${{ github.workspace }}
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -73,6 +73,8 @@ jobs:
         with:
           shopware-version: ${{ matrix.version }}
           php-version: ${{ matrix.php-version }}
+          php-extensions: pcov
+          install: true
 
       - name: Info
         run: |
@@ -80,7 +82,6 @@ jobs:
           mysql -V
           php -v
           composer -V
-          echo ${{ github.workspace }}
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -1,3 +1,6 @@
+# 5.1.0
+* Add variable mediaUpdatedAt for paths to prevent caching
+
 # 5.0.1
 * Fix support for cloning product entity
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Available variables with examples:
 * {mediaUrl}: https://www.example.com/
 * {mediaPath}: media/01/82/69/sasse.png
 * {width}: 800
-* {mediaUpdatedAt}: 1716882050 (unix timestamp) or null
+* {mediaUpdatedAt}: 1716882050 (unix timestamp) or 0
 
 Feel free to decorate `ThumbnailUrlTemplateInterface` to add more individual functions like [signed imgproxy](https://github.com/FriendsOfShopware/FroshPlatformThumbnailProcessorImgProxy)
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Available variables with examples:
 * {mediaUrl}: https://www.example.com/
 * {mediaPath}: media/01/82/69/sasse.png
 * {width}: 800
+* {mediaUpdatedAt}: 1716882050 (unix timestamp) or null
 
 Feel free to decorate `ThumbnailUrlTemplateInterface` to add more individual functions like [signed imgproxy](https://github.com/FriendsOfShopware/FroshPlatformThumbnailProcessorImgProxy)
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "thumbnail"
     ],
     "description": "This plugins allows you to use variable thumbnails, without having them on storage.",
-    "version": "5.0.1",
+    "version": "5.1.0",
     "type": "shopware-platform-plugin",
     "license": "mit",
     "authors": [

--- a/src/Core/Media/MediaUrlGenerator.php
+++ b/src/Core/Media/MediaUrlGenerator.php
@@ -51,7 +51,8 @@ class MediaUrlGenerator extends AbstractMediaUrlGenerator
             $urls[$key] = $this->thumbnailUrlTemplate->getUrl(
                 $baseUrl,
                 $value->path,
-                $this->getWidth($maxWidth, $value)
+                $this->getWidth($maxWidth, $value),
+                $value->updatedAt
             );
         }
 

--- a/src/Resources/app/administration/src/module/frosh-thumbnail-processor/frosh-thumbnail-processor-info-texts/frosh-thumbnail-processor-info-texts.html.twig
+++ b/src/Resources/app/administration/src/module/frosh-thumbnail-processor/frosh-thumbnail-processor-info-texts/frosh-thumbnail-processor-info-texts.html.twig
@@ -9,7 +9,7 @@
             <b>{mediaUrl}</b>: e.g. https://cdn.test.de/<br>
             <b>{mediaPath}</b>: e.g. media/image/5b/6d/16/tea.png<br>
             <b>{width}</b>: e.g. 800
-            <b>{mediaUpdatedAt}</b>: 1716882050 (unix timestamp) or null
+            <b>{mediaUpdatedAt}</b>: 1716882050 (unix timestamp) or 0
         </p>
 
         <p>

--- a/src/Resources/app/administration/src/module/frosh-thumbnail-processor/frosh-thumbnail-processor-info-texts/frosh-thumbnail-processor-info-texts.html.twig
+++ b/src/Resources/app/administration/src/module/frosh-thumbnail-processor/frosh-thumbnail-processor-info-texts/frosh-thumbnail-processor-info-texts.html.twig
@@ -9,6 +9,7 @@
             <b>{mediaUrl}</b>: e.g. https://cdn.test.de/<br>
             <b>{mediaPath}</b>: e.g. media/image/5b/6d/16/tea.png<br>
             <b>{width}</b>: e.g. 800
+            <b>{mediaUpdatedAt}</b>: 1716882050 (unix timestamp) or null
         </p>
 
         <p>

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -21,7 +21,7 @@
                 {mediaUrl}: https://cdn.test.de/<br>
                 {mediaPath}: media/image/5b/6d/16/tea.png<br>
                 {width}: 800<br>
-                {mediaUpdatedAt}: 1716882050 (unix timestamp) or null
+                {mediaUpdatedAt}: 1716882050 (unix timestamp) or 0
             ]]></helpText>
         </input-field>
 

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -20,7 +20,8 @@
             <helpText><![CDATA[available variables:<br>
                 {mediaUrl}: https://cdn.test.de/<br>
                 {mediaPath}: media/image/5b/6d/16/tea.png<br>
-                {width}: 800
+                {width}: 800<br>
+                {mediaUpdatedAt}: 1716882050 (unix timestamp) or null
             ]]></helpText>
         </input-field>
 

--- a/src/Service/ThumbnailUrlTemplate.php
+++ b/src/Service/ThumbnailUrlTemplate.php
@@ -11,11 +11,11 @@ class ThumbnailUrlTemplate implements ThumbnailUrlTemplateInterface
     ) {
     }
 
-    public function getUrl(string $mediaUrl, string $mediaPath, string $width): string
+    public function getUrl(string $mediaUrl, string $mediaPath, string $width, ?\DateTimeInterface $mediaUpdatedAt): string
     {
         return str_replace(
-            ['{mediaUrl}', '{mediaPath}', '{width}'],
-            [$mediaUrl, $mediaPath, $width],
+            ['{mediaUrl}', '{mediaPath}', '{width}', '{mediaUpdatedAt}'],
+            [$mediaUrl, $mediaPath, $width, $mediaUpdatedAt?->getTimestamp() ?: 'null'],
             $this->getPattern()
         );
     }

--- a/src/Service/ThumbnailUrlTemplate.php
+++ b/src/Service/ThumbnailUrlTemplate.php
@@ -15,7 +15,7 @@ class ThumbnailUrlTemplate implements ThumbnailUrlTemplateInterface
     {
         return str_replace(
             ['{mediaUrl}', '{mediaPath}', '{width}', '{mediaUpdatedAt}'],
-            [$mediaUrl, $mediaPath, $width, $mediaUpdatedAt?->getTimestamp() ?: 'null'],
+            [$mediaUrl, $mediaPath, $width, $mediaUpdatedAt?->getTimestamp() ?: '0'],
             $this->getPattern()
         );
     }

--- a/src/Service/ThumbnailUrlTemplateInterface.php
+++ b/src/Service/ThumbnailUrlTemplateInterface.php
@@ -4,5 +4,5 @@ namespace Frosh\ThumbnailProcessor\Service;
 
 interface ThumbnailUrlTemplateInterface
 {
-    public function getUrl(string $mediaUrl, string $mediaPath, string $width): string;
+    public function getUrl(string $mediaUrl, string $mediaPath, string $width, ?\DateTimeInterface $mediaUpdatedAt): string;
 }

--- a/tests/unit/Service/ThumbnailUrlTemplateTest.php
+++ b/tests/unit/Service/ThumbnailUrlTemplateTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Frosh\ThumbnailProcessor\TestsUnit\Service;
+namespace Frosh\ThumbnailProcessor\Tests\Unit\Service;
 
 use Frosh\ThumbnailProcessor\Service\ConfigReader;
 use Frosh\ThumbnailProcessor\Service\ThumbnailUrlTemplate;
@@ -22,7 +22,7 @@ class ThumbnailUrlTemplateTest extends TestCase
 
         $url = $class->getUrl($mediaUrl, $mediaPath, $width, $date);
 
-        static::assertSame(\sprintf('%s/%s?width=%s&updatedAt=%s&uff', $mediaUrl, $mediaPath, $width, $date?->getTimestamp() ?? 'null'), $url);
+        static::assertSame(\sprintf('%s/%s?width=%s&updatedAt=%s&uff', $mediaUrl, $mediaPath, $width, $date?->getTimestamp() ?: '0'), $url);
     }
 
     /**
@@ -38,7 +38,7 @@ class ThumbnailUrlTemplateTest extends TestCase
 
         $url = $class->getUrl($mediaUrl, $mediaPath, $width, $date);
 
-        static::assertSame(\sprintf('%s/%s?width=%s&updatedAt=%s', $mediaUrl, $mediaPath, $width, $date?->getTimestamp() ?? 'null'), $url);
+        static::assertSame(\sprintf('%s/%s?width=%s&updatedAt=%s', $mediaUrl, $mediaPath, $width, $date?->getTimestamp() ?: '0'), $url);
     }
 
     /**
@@ -56,7 +56,7 @@ class ThumbnailUrlTemplateTest extends TestCase
 
         $url = $class->getUrl($mediaUrl, $mediaPath, $width, $date);
 
-        static::assertSame(\sprintf('%s/%s?width=%s&updatedAt=%s', $mediaUrl, $mediaPath, $width, $date?->getTimestamp() ?? 'null'), $url);
+        static::assertSame(\sprintf('%s/%s?width=%s&updatedAt=%s', $mediaUrl, $mediaPath, $width, $date?->getTimestamp() ?: '0'), $url);
     }
 
     /**

--- a/tests/unit/Service/ThumbnailUrlTemplateTest.php
+++ b/tests/unit/Service/ThumbnailUrlTemplateTest.php
@@ -9,54 +9,54 @@ use Shopware\Core\Framework\Uuid\Uuid;
 
 class ThumbnailUrlTemplateTest extends TestCase
 {
-    /**
+	/**
      * @dataProvider getSalesChannelIds
      */
-    public function testGetUrl(?string $salesChannelId, string $mediaUrl, string $mediaPath, string $width): void
+    public function testGetUrl(?string $salesChannelId, string $mediaUrl, string $mediaPath, string $width, ?\DateTimeInterface $date): void
     {
         $configReader = $this->createMock(ConfigReader::class);
         $configReader->expects(static::once())
-            ->method('getConfig')->willReturn('{mediaUrl}/{mediaPath}?width={width}&uff');
+            ->method('getConfig')->willReturn('{mediaUrl}/{mediaPath}?width={width}&updatedAt={mediaUpdatedAt}&uff');
 
         $class = new ThumbnailUrlTemplate($configReader);
 
-        $url = $class->getUrl($mediaUrl, $mediaPath, $width);
+        $url = $class->getUrl($mediaUrl, $mediaPath, $width, $date);
 
-        static::assertSame(\sprintf('%s/%s?width=%s&uff', $mediaUrl, $mediaPath, $width), $url);
+        static::assertSame(\sprintf('%s/%s?width=%s&updatedAt=%s&uff', $mediaUrl, $mediaPath, $width, $date?->getTimestamp() ?? 'null'), $url);
     }
 
     /**
      * @dataProvider getSalesChannelIds
      */
-    public function testGetUrlWithoutSetConfig(?string $salesChannelId, string $mediaUrl, string $mediaPath, string $width): void
+    public function testGetUrlWithoutSetConfig(?string $salesChannelId, string $mediaUrl, string $mediaPath, string $width, ?\DateTimeInterface $date): void
     {
         $configReader = $this->createMock(ConfigReader::class);
         $configReader->expects(static::once())
-            ->method('getConfig')->willReturn('{mediaUrl}/{mediaPath}?width={width}');
+            ->method('getConfig')->willReturn('{mediaUrl}/{mediaPath}?width={width}&updatedAt={mediaUpdatedAt}');
 
         $class = new ThumbnailUrlTemplate($configReader);
 
-        $url = $class->getUrl($mediaUrl, $mediaPath, $width);
+        $url = $class->getUrl($mediaUrl, $mediaPath, $width, $date);
 
-        static::assertSame(\sprintf('%s/%s?width=%s', $mediaUrl, $mediaPath, $width), $url);
+        static::assertSame(\sprintf('%s/%s?width=%s&updatedAt=%s', $mediaUrl, $mediaPath, $width, $date?->getTimestamp() ?? 'null'), $url);
     }
 
     /**
      * @dataProvider getSalesChannelIds
      */
-    public function testGetUrlGetPatternOnce(?string $salesChannelId, string $mediaUrl, string $mediaPath, string $width): void
+    public function testGetUrlGetPatternOnce(?string $salesChannelId, string $mediaUrl, string $mediaPath, string $width, ?\DateTimeInterface $date): void
     {
         $configReader = $this->createMock(ConfigReader::class);
         $configReader->expects(static::once())
-            ->method('getConfig')->willReturn('{mediaUrl}/{mediaPath}?width={width}');
+            ->method('getConfig')->willReturn('{mediaUrl}/{mediaPath}?width={width}&updatedAt={mediaUpdatedAt}');
 
         $class = new ThumbnailUrlTemplate($configReader);
 
-        $class->getUrl($mediaUrl, $mediaPath, $width);
+        $class->getUrl($mediaUrl, $mediaPath, $width, $date);
 
-        $url = $class->getUrl($mediaUrl, $mediaPath, $width);
+        $url = $class->getUrl($mediaUrl, $mediaPath, $width, $date);
 
-        static::assertSame(\sprintf('%s/%s?width=%s', $mediaUrl, $mediaPath, $width), $url);
+        static::assertSame(\sprintf('%s/%s?width=%s&updatedAt=%s', $mediaUrl, $mediaPath, $width, $date?->getTimestamp() ?? 'null'), $url);
     }
 
     /**
@@ -64,10 +64,11 @@ class ThumbnailUrlTemplateTest extends TestCase
      */
     public static function getSalesChannelIds(): iterable
     {
-        yield [null, 'https://www.anywebpage.test', 'media/78/a1/myimage.jpg', '200'];
-        yield [Uuid::randomHex(), 'https://www.anyotherwebpage.test', 'media/aa/a1/myimage.jpg', '300'];
-        yield [Uuid::randomHex(), 'https://www.anyother2webpage.test', 'media/aa/bb/myimage.jpg', '700'];
-        yield [Uuid::randomHex(), 'https://www.anyother3webpage.test', 'media/aa/cc/myimage.jpg', '900'];
-        yield [Uuid::randomHex(), 'https://www.anyother4webpage.test', 'media/aa/dd/myimage.jpg', '1000'];
+        yield [null, 'https://www.anywebpage.test', 'media/78/a1/myimage.jpg', '200', null];
+        yield [null, 'https://www.anyotherwebpage.test', 'media/78/a1/myimage.jpg', '200', new \DateTimeImmutable()];
+        yield [Uuid::randomHex(), 'https://www.anyother2webpage.test', 'media/aa/a1/myimage.jpg', '300', new \DateTimeImmutable()];
+        yield [Uuid::randomHex(), 'https://www.anyother3webpage.test', 'media/aa/bb/myimage.jpg', '700', null];
+        yield [Uuid::randomHex(), 'https://www.anyother4webpage.test', 'media/aa/cc/myimage.jpg', '900', new \DateTimeImmutable()];
+        yield [Uuid::randomHex(), 'https://www.anyother5webpage.test', 'media/aa/dd/myimage.jpg', '1000', null];
     }
 }


### PR DESCRIPTION
This implements the feature request #131.

It passes an additional argument `?DateTimeInterface mediaUpdatedAt` to `ThumbnailUrlTemplateInterface::getUrl`.
This allows custom handling of the DateTime in the Implementation.

In the default implementation, the value is converted into a unix timestamp or string `null` and available as `{mediaUpdatedAt}` in the pattern.

Looking forward to your feedback.