### PR TITLE
fix: duplicated slashes after domain

### DIFF
--- a/src/Service/UrlGeneratorDecorator.php
+++ b/src/Service/UrlGeneratorDecorator.php
@@ -82,7 +82,7 @@ class UrlGeneratorDecorator implements UrlGeneratorInterface, ResetInterface
 
     private function getBaseUrl(): string
     {
-        return $this->filesystem->publicUrl('');
+        return \rtrim($this->filesystem->publicUrl(''), '/');
     }
 
     private function canProcessFileExtension(?string $fileExtension): bool


### PR DESCRIPTION
### 🛠️ Fix: Double Slash in Media URL (Causing 301 Redirect)

#### Summary
This PR fixes an issue where generated media URLs contain a double slash (`//`) before the `/media` path, which leads to unnecessary `301 Moved Permanently` redirects.

#### 🧩 Configuration Example

```yaml
shopware:
  filesystem:
    public:
      url: "https://cdn.example.org"
      type: "local"
      config:
        root: "%kernel.project_dir%/public"
```

#### ✅ Expected Result
```
https://cdn.example.org/media/cd/b3/7a/1714460064/traily.png?width=3000
```

#### ❌ Actual Result
```
https://cdn.example.org//media/cd/b3/7a/1714460064/traily.png?width=3000
```

#### 🔍 Note:
A similar issue may also occur in 5.x version, if a comparable URL composition logic is used. However, this has not yet been tested in that version.


