### PR TITLE
fix: GeneratorCompilerPass for ThumbnailService

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get Shopware Version
         id: shopware-constraint
@@ -55,7 +55,7 @@ jobs:
           composer -V
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{ github.workspace }}/custom/plugins/${{ env.PLUGIN_NAME }}
 
@@ -65,7 +65,7 @@ jobs:
           composer create-placeholders
           php -d pcov.enabled=1 ${{ github.workspace }}/vendor/bin/phpunit --coverage-clover clover.xml --testsuite Unit
 
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -102,7 +102,7 @@ jobs:
           composer -V
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{ github.workspace }}/custom/plugins/${{ env.PLUGIN_NAME }}
 
@@ -112,7 +112,7 @@ jobs:
           composer create-placeholders
           php -d pcov.enabled=1 ${{ github.workspace }}/vendor/bin/phpunit --testsuite Integration
 
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/src/Controller/Api/TestController.php
+++ b/src/Controller/Api/TestController.php
@@ -19,6 +19,7 @@ use Shopware\Core\PlatformRequest;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
+use Shopware\Core\Content\Media\Aggregate\MediaFolder\MediaFolderCollection;
 
 #[Route(defaults: ['_routeScope' => ['api']])]
 class TestController
@@ -26,6 +27,10 @@ class TestController
     public const REQUEST_ATTRIBUTE_TEST_ACTIVE = 'FroshPlatformThumbnailProcessorTestActive';
     public const TEST_FILE_PATH = __DIR__ . '/../../Resources/data/froshthumbnailprocessortestimage.jpg';
 
+    /**
+     * @param EntityRepository<MediaCollection> $mediaRepository
+     * @param EntityRepository<MediaFolderCollection> $mediaFolderRepository
+     */
     public function __construct(
         private readonly AbstractMediaUrlGenerator $urlGenerator,
         private readonly EntityRepository $mediaRepository,
@@ -143,7 +148,6 @@ class TestController
         // we use the fileName filter to add backward compatibility
         $criteria->addFilter(new EqualsFilter('fileName', $fileName));
 
-        /** @var MediaCollection $entities */
         $entities = $this->mediaRepository->search($criteria, $context)->getEntities();
 
         return $entities->first();

--- a/src/EventListener/ThumbnailSizesChangedListener.php
+++ b/src/EventListener/ThumbnailSizesChangedListener.php
@@ -2,7 +2,6 @@
 
 namespace Frosh\ThumbnailProcessor\EventListener;
 
-use Shopware\Core\Content\Media\Aggregate\MediaFolder\MediaFolderEntity;
 use Shopware\Core\Content\Media\Aggregate\MediaFolderConfigurationMediaThumbnailSize\MediaFolderConfigurationMediaThumbnailSizeDefinition;
 use Shopware\Core\Content\Media\Commands\GenerateThumbnailsCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -12,9 +11,13 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Core\Content\Media\Aggregate\MediaFolder\MediaFolderCollection;
 
 class ThumbnailSizesChangedListener implements EventSubscriberInterface
 {
+    /**
+     * @param EntityRepository<MediaFolderCollection> $mediaFolderRepository
+     */
     public function __construct(
         private readonly GenerateThumbnailsCommand $generateThumbnailsCommand,
         private readonly EntityRepository $mediaFolderRepository,
@@ -52,7 +55,6 @@ class ThumbnailSizesChangedListener implements EventSubscriberInterface
 
         $result = $this->mediaFolderRepository->search($criteria, $event->getContext());
 
-        /** @var MediaFolderEntity $entity */
         foreach ($result->getEntities() as $entity) {
             $parameters = [];
 

--- a/src/Service/SalesChannelIdDetector.php
+++ b/src/Service/SalesChannelIdDetector.php
@@ -10,9 +10,13 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\PlatformRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Shopware\Core\Content\ProductExport\ProductExportCollection;
 
 class SalesChannelIdDetector
 {
+    /**
+     * @param EntityRepository<ProductExportCollection> $productExportRepository
+     */
     public function __construct(
         private readonly RequestStack $requestStack,
         private readonly EntityRepository $productExportRepository

--- a/tests/integration/MediaUrlTest.php
+++ b/tests/integration/MediaUrlTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailCollection;
 use Shopware\Core\Content\Media\Commands\GenerateThumbnailsCommand;
 use Shopware\Core\Content\Media\Core\Application\AbstractMediaUrlGenerator;
-use Shopware\Core\Content\Media\MediaEntity;
+use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Test\Media\MediaFixtures;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -18,7 +18,6 @@ use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class MediaUrlTest extends TestCase
 {
@@ -26,6 +25,9 @@ class MediaUrlTest extends TestCase
     use MediaFixtures;
     use QueueTestBehaviour;
 
+    /**
+     * @var EntityRepository<MediaCollection>
+     */
     private EntityRepository $mediaRepository;
 
     private GenerateThumbnailsCommand $generateThumbnailsCommand;
@@ -90,7 +92,6 @@ class MediaUrlTest extends TestCase
 
         $mediaResult = $this->mediaRepository->search($searchCriteria, $this->context);
 
-        /** @var MediaEntity $updatedMedia */
         $updatedMedia = $mediaResult->getEntities()->first();
 
         $thumbnails = $updatedMedia->getThumbnails();
@@ -150,7 +151,6 @@ class MediaUrlTest extends TestCase
 
         $mediaResult = $this->mediaRepository->search($searchCriteria, $this->context);
 
-        /** @var MediaEntity $updatedMedia */
         $updatedMedia = $mediaResult->getEntities()->first();
 
         $thumbnails = $updatedMedia->getThumbnails();


### PR DESCRIPTION
- This PR fixes the issues with the latest trunk changes while still being backwards compatible with all old Shopware versions.

- Fix #163