### PR TITLE
Update UrlEncodingTwigFilter.php

### DIFF
--- a/src/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilter.php
+++ b/src/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilter.php
@@ -17,6 +17,6 @@ class UrlEncodingTwigFilter extends ShopwareUrlEncodingTwigFilter
         }
 
         // this adds support for imgproxy with the procession options coming with version 3.0
-        return \str_replace('%3A', ':', $mediaUrl);
+        return str_ireplace(['%40', '%3A'], ['@', ':'], $mediaUrl);
     }
 }

--- a/src/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilter.php
+++ b/src/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilter.php
@@ -17,6 +17,6 @@ class UrlEncodingTwigFilter extends ShopwareUrlEncodingTwigFilter
         }
 
         // this adds support for imgproxy with the procession options coming with version 3.0
-        return str_replace(['%40', '%3A'], ['@', ':'], $mediaUrl);
+        return \str_replace(['%40', '%3A'], ['@', ':'], $mediaUrl);
     }
 }

--- a/src/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilter.php
+++ b/src/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilter.php
@@ -17,6 +17,6 @@ class UrlEncodingTwigFilter extends ShopwareUrlEncodingTwigFilter
         }
 
         // this adds support for imgproxy with the procession options coming with version 3.0
-        return str_ireplace(['%40', '%3A'], ['@', ':'], $mediaUrl);
+        return str_replace(['%40', '%3A'], ['@', ':'], $mediaUrl);
     }
 }


### PR DESCRIPTION
Description:

This PR updates the media URL transformation to avoid encoding @ and : characters, which are critical for correctly matching URLs during production deployments with [imgproxy](https://github.com/shinsenter/docker-imgproxy) (other Project) with nginx caching.

Before:

@ was being URL-encoded to %40, and : to %3A, which caused issues with imgproxy’s signature validation and access patterns.

This ensures the @ and : characters remain intact after URL encoding, fixing matching issues in production.

Why it matters:

The default URL-encoding breaks compatibility with imgproxy’s signed URL verification and can prevent media from being loaded properly in production setups that rely on those characters being preserved.